### PR TITLE
[Add] 다이어리 리스트 순서 변경 기능 추가

### DIFF
--- a/Dayol-iOS/UI/Home/DiaryList/View/DiaryListCell.swift
+++ b/Dayol-iOS/UI/Home/DiaryList/View/DiaryListCell.swift
@@ -42,6 +42,15 @@ class DiaryListCell: UICollectionViewCell {
     static let identifier = "\(DiaryListCell.self)"
 
     private let disposeBag = DisposeBag()
+    // TODO: - 다이어리 리스트 편집 시 다이어리 커버 스케일 줄이는 애니메이션 자연스럽게
+    var isEditMode = false {
+        didSet {
+            mainStackView.alpha = isEditMode ? 0 : 1
+            diaryCoverView.alpha = isEditMode ? 0.5 : 1
+            let scale: CGFloat = isEditMode ? 0.5 : 1.0
+            contentView.transform = CGAffineTransform(scaleX: scale, y: scale)
+        }
+    }
     var viewModel: DiaryCoverModel? {
         didSet {
             configure()
@@ -50,7 +59,7 @@ class DiaryListCell: UICollectionViewCell {
 
     // MARK: - UI
 
-    private let diaryCoverView: DiaryView = {
+    private(set) var diaryCoverView: DiaryView = {
         let coverView = DiaryView(type: Design.diaryCoverSize)
         coverView.translatesAutoresizingMaskIntoConstraints = false
         return coverView
@@ -104,6 +113,7 @@ class DiaryListCell: UICollectionViewCell {
         diaryCoverView.backgroundColor = .none
         titleLabel.attributedText = .none
         subTitleLabel.attributedText = .none
+        isEditMode = false
     }
 
     // MARK: - Bind ViewModel
@@ -112,7 +122,6 @@ class DiaryListCell: UICollectionViewCell {
         guard let viewModel = viewModel else { return }
         let subTitle = "\(viewModel.totalPage)page"
 
-        // TODO: - 다이어리 커버 뷰 작업
         diaryCoverView.setCover(color: viewModel.coverColor)
         titleLabel.attributedText = Design.attributedTitle(text: viewModel.title)
         subTitleLabel.attributedText = Design.attributedSubTitle(text: subTitle)
@@ -137,11 +146,11 @@ extension DiaryListCell {
 
     private func setupConstraints() {
         NSLayoutConstraint.activate([
-            diaryCoverView.topAnchor.constraint(equalTo: topAnchor),
-            diaryCoverView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            diaryCoverView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            diaryCoverView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
 
-            mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            mainStackView.centerXAnchor.constraint(equalTo: centerXAnchor)
+            mainStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            mainStackView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor)
         ])
     }
 }

--- a/Dayol-iOS/UI/Home/DiaryList/View/DiaryListCell.swift
+++ b/Dayol-iOS/UI/Home/DiaryList/View/DiaryListCell.swift
@@ -40,6 +40,10 @@ private enum Design {
 
 class DiaryListCell: UICollectionViewCell {
     static let identifier = "\(DiaryListCell.self)"
+    enum Size {
+        static let `default` = CGSize(width: 278, height: 432)
+        static let edit = CGSize(width: 139, height: 216)
+    }
 
     private let disposeBag = DisposeBag()
     // TODO: - 다이어리 리스트 편집 시 다이어리 커버 스케일 줄이는 애니메이션 자연스럽게

--- a/Dayol-iOS/UI/Home/DiaryList/ViewController/DiaryListViewController+CollectionView.swift
+++ b/Dayol-iOS/UI/Home/DiaryList/ViewController/DiaryListViewController+CollectionView.swift
@@ -35,7 +35,80 @@ extension DiaryListViewController: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         diaryListCell.viewModel = viewModel
+        diaryListCell.isEditMode = isEditMode
+
         return diaryListCell
     }
 
+    func collectionView(_ collectionView: UICollectionView, moveItemAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        viewModel.moveItem(at: sourceIndexPath.row, to: destinationIndexPath.row)
+    }
+
+}
+
+// MARK: - UICollectionView Reorder
+
+extension DiaryListViewController {
+
+    @objc func didRecongizeLongPress(_ recog: UIGestureRecognizer) {
+        let point = recog.location(in: collectionView)
+        switch recog.state {
+        case .began:
+            guard
+                let indexPath = collectionView.indexPathForItem(at: point),
+                isEditMode == false
+            else {
+                collectionView.cancelInteractiveMovement()
+                return
+            }
+
+            isEditMode = true
+            startEditMode(indexPath) { [weak self] in
+                guard let self = self else { return }
+                self.canStartInteractiveMovement = true
+                self.currentEditIndex = indexPath
+                self.collectionView.beginInteractiveMovementForItem(at: indexPath)
+            }
+        case .changed:
+            guard isEditMode, canStartInteractiveMovement else { return }
+            collectionView.updateInteractiveMovementTargetPosition(point)
+        case .ended:
+            isEditMode = false
+            canStartInteractiveMovement = false
+            endEditMode { [weak self] in
+                guard let self = self else { return }
+                self.collectionView.endInteractiveMovement()
+            }
+        default:
+            isEditMode = false
+            canStartInteractiveMovement = false
+            collectionView.cancelInteractiveMovement()
+            endEditMode()
+        }
+    }
+
+    private func startEditMode(_ indexPath: IndexPath, completion: (() -> Void)? = nil) {
+        collectionView.visibleCells.enumerated().forEach { index, cell in
+            guard let diaryCell = cell as? DiaryListCell else { return }
+            diaryCell.isEditMode = true
+        }
+
+        if let diaryCell = collectionView.cellForItem(at: indexPath) as? DiaryListCell {
+            diaryCell.diaryCoverView.alpha = 1
+        }
+        
+        collectionView.setCollectionViewLayout(collectionViewFlowLayout, animated: false) { _ in
+            completion?()
+        }
+    }
+
+    private func endEditMode(completion: (() -> Void)? = nil) {
+        collectionView.visibleCells.forEach { cell in
+            guard let diaryCell = cell as? DiaryListCell else { return }
+            diaryCell.isEditMode = false
+        }
+        collectionView.setCollectionViewLayout(collectionViewFlowLayout, animated: false) { _ in
+            completion?()
+        }
+    }
 }

--- a/Dayol-iOS/UI/Home/DiaryList/ViewController/DiaryListViewController+CollectionView.swift
+++ b/Dayol-iOS/UI/Home/DiaryList/ViewController/DiaryListViewController+CollectionView.swift
@@ -51,6 +51,7 @@ extension DiaryListViewController: UICollectionViewDataSource {
 extension DiaryListViewController {
 
     @objc func didRecongizeLongPress(_ recog: UIGestureRecognizer) {
+        guard viewModel.diaryList.count > 1 else { return }
         let point = recog.location(in: collectionView)
         switch recog.state {
         case .began:

--- a/Dayol-iOS/UI/Home/DiaryList/ViewController/DiaryListViewController.swift
+++ b/Dayol-iOS/UI/Home/DiaryList/ViewController/DiaryListViewController.swift
@@ -21,7 +21,7 @@ private enum Design {
         return 60.0
     }
     static func getItemSize(isEditMode: Bool) -> CGSize {
-        return isEditMode ? CGSize(width: 139, height: 216) : CGSize(width: 278, height: 432)
+        return isEditMode ? DiaryListCell.Size.edit : DiaryListCell.Size.default
     }
 }
 


### PR DESCRIPTION
## Description  
다이어리 리스트 순서 변경 기능 추가  

## Detail  
- 롱탭 제스터를 사용하여 순서 변경 모드 진업점 및 interative movement 구현   
- 순서 변경 모드 진입 시 플로우
  1.라벨을 제거  
  2.현재 순서 변경의 대상 다이어리를 제외한 모든 다이어리는 alpha값을 50%로 조정
  3.cell의 사이즈를 줄여 collectionView의 레이아웃을 다시 설정

## Demo  
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/46941349/103474158-60644b80-4de4-11eb-90e9-4f97aa35f14e.gif)  

## Todo  
다이어리 리스트 스냅 스크롤을 구현  
순서 재정렬 후 재정렬 한 다이어리로 이동하는 로직 추가  

