### PR TITLE
 [Add] System Photo Picker 기능 추가

### DIFF
--- a/Dayol-iOS.xcodeproj/project.pbxproj
+++ b/Dayol-iOS.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3434B76B25A4797B00506152 /* DYModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3434B76A25A4797B00506152 /* DYModalViewController.swift */; };
 		3434B76F25A479D800506152 /* DYModalConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3434B76E25A479D800506152 /* DYModalConfiguration.swift */; };
+		346779C425B47C6F001427F8 /* DiaryEditViewController+PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346779C325B47C6F001427F8 /* DiaryEditViewController+PhotoPicker.swift */; };
 		34CA253A25A613220057404D /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 34CA253C25A613220057404D /* Localizable.strings */; };
 		34CA254225A613CE0057404D /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CA254125A613CE0057404D /* String+Extension.swift */; };
 		34CA254625A6190D0057404D /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CA254525A6190D0057404D /* SettingsViewController.swift */; };
@@ -75,6 +76,7 @@
 		2D2405592E98948CDE582F1F /* Pods-Dayol-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Dayol-iOS.debug.xcconfig"; path = "Target Support Files/Pods-Dayol-iOS/Pods-Dayol-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		3434B76A25A4797B00506152 /* DYModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DYModalViewController.swift; sourceTree = "<group>"; };
 		3434B76E25A479D800506152 /* DYModalConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DYModalConfiguration.swift; sourceTree = "<group>"; };
+		346779C325B47C6F001427F8 /* DiaryEditViewController+PhotoPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DiaryEditViewController+PhotoPicker.swift"; sourceTree = "<group>"; };
 		34CA253B25A613220057404D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		34CA253E25A613540057404D /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		34CA253F25A613540057404D /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -497,6 +499,7 @@
 			children = (
 				DADD0A0325A3542F004D6CF0 /* Cell */,
 				DAD66733259B551600E8F59A /* DiaryEditViewController.swift */,
+				346779C325B47C6F001427F8 /* DiaryEditViewController+PhotoPicker.swift */,
 				DADD09F625A335C2004D6CF0 /* DiaryEditToggleView.swift */,
 				DADD09FA25A33674004D6CF0 /* DiaryEditCoverView.swift */,
 				DADD09FD25A33695004D6CF0 /* DiaryEditColorPaletteView.swift */,
@@ -702,6 +705,7 @@
 				CE8DCAE0258D28F4007738EA /* DiaryListViewController.swift in Sources */,
 				CE8DCB2D258FB1A0007738EA /* DiaryListViewController+bind.swift in Sources */,
 				DADD09FE25A33695004D6CF0 /* DiaryEditColorPaletteView.swift in Sources */,
+				346779C425B47C6F001427F8 /* DiaryEditViewController+PhotoPicker.swift in Sources */,
 				DAE29CEB2584F2100028010B /* PasswordViewController.swift in Sources */,
 				34CA255825A74A7A0057404D /* SettingsViewModel.swift in Sources */,
 				DA4899E7257A08A6005E39ED /* AppDelegate.swift in Sources */,

--- a/Dayol-iOS/UI/DiaryEdit/View/DiaryEditViewController+PhotoPicker.swift
+++ b/Dayol-iOS/UI/DiaryEdit/View/DiaryEditViewController+PhotoPicker.swift
@@ -1,0 +1,78 @@
+//
+//  DiaryEditViewController+PhotoPicker.swift
+//  Dayol-iOS
+//
+//  Created by 주성민 on 2021/01/17.
+//
+
+import UIKit
+import Photos
+import PhotosUI
+
+extension DiaryEditViewController {
+
+    func showPicker() {
+        if #available(iOS 14.0, *) {
+            var configuration = PHPickerConfiguration()
+            configuration.selectionLimit = 1
+            configuration.filter = .any(of: [.images])
+
+            let picker = PHPickerViewController(configuration: configuration)
+            picker.delegate = self
+            present(picker, animated: true, completion: nil)
+
+        } else {
+            let picker = UIImagePickerController()
+            picker.delegate = self
+            picker.sourceType = .photoLibrary
+
+            if UIImagePickerController.isSourceTypeAvailable(.photoLibrary) {
+                present(picker, animated: true)
+            }
+        }
+    }
+}
+
+extension DiaryEditViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
+            let imageView = UIImageView()
+            imageView.frame = CGRect(x: self.view.center.x - 50,
+                                     y: self.view.center.y - 50,
+                                     width: 100,
+                                     height: 100)
+            imageView.image = image
+            view.addSubview(imageView)
+        }
+        dismiss(animated: true, completion: nil)
+    }
+
+}
+
+
+extension DiaryEditViewController: PHPickerViewControllerDelegate {
+
+    @available(iOS 14.0, *)
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true, completion: nil)
+
+        let itemProvider = results.first?.itemProvider
+        if let itemProvider = itemProvider, itemProvider.canLoadObject(ofClass: UIImage.self) {
+            itemProvider.loadObject(ofClass: UIImage.self) { [weak self] (image, error) in
+                guard let self = self, let image = image as? UIImage else { return }
+
+                DispatchQueue.main.async {
+                    let imageView = UIImageView()
+                    imageView.image = image
+                    imageView.frame = CGRect(x: self.view.center.x - 50,
+                                             y: self.view.center.y - 50,
+                                             width: 100,
+                                             height: 100)
+                    self.view.addSubview(imageView)
+                }
+            }
+        }
+    }
+
+}

--- a/Dayol-iOS/UI/DiaryEdit/View/DiaryEditViewController.swift
+++ b/Dayol-iOS/UI/DiaryEdit/View/DiaryEditViewController.swift
@@ -131,5 +131,11 @@ class DiaryEditViewController: UIViewController {
                 self?.titleView.isEditting = true
             }
             .disposed(by: disposeBag)
+
+        toolBar.photoButton.rx.tap
+            .bind { [weak self] in
+                self?.showPicker()
+            }
+            .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
## Description  
다이어리 생성 -> 이미지 버튼 탭 -> 이미지 피커 뷰로 이동하여 이미지 선택할 수 있는 기능 추가 했습니다.  
선택한 이미지로 이미지 뷰를 생성하여 현재 뷰에 addSubview 하도록 구현해두었는데요.  
데모 진행 후, 혹은 실제 기능 연동시 수정하면 될 것 같습니다.  

추가로 시스템 피커를 사용하면 따로 권한과 관련된 작업을 스킵해도 된다는 것 같아서 우선 피커만 띄우도록 구현했는데요.  
이부분은 좀 더 확인해보고 공유 드리도록 하겠습니다.  



### Demo  
- iOS 13.0
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/46941349/104846188-a52bce80-591c-11eb-9d9b-f2ff6e8b1dfc.gif)  
- iOS 14.0  
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/46941349/104846192-a78e2880-591c-11eb-8405-58a9bc978139.gif)
