### PR TITLE
[Add] 1차 속지 데이터 연결

### DIFF
--- a/Dayol-iOS/TestData/DiaryPageTestData.swift
+++ b/Dayol-iOS/TestData/DiaryPageTestData.swift
@@ -18,6 +18,7 @@ struct DiaryInnerModel {
         let id: Int
         let paperStyle: PaperStyle
         let paperType: PaperType
+        // TODO: - 속지 추가 스펙이 있어서 [DrawModel] 로 변경되어야 할 것 같습니다.
         var drawModelList: DrawModel
     }
 

--- a/Dayol-iOS/UI/DiaryPaper/Papers/PaperPresentView.swift
+++ b/Dayol-iOS/UI/DiaryPaper/Papers/PaperPresentView.swift
@@ -10,9 +10,6 @@ import RxSwift
 class PaperPresentView: UIView {
 
     let paperStyle: PaperStyle
-    open var canAddPage: Bool {
-        return false
-    }
 
     // UI
 
@@ -26,9 +23,16 @@ class PaperPresentView: UIView {
         return scrollView
     }()
 
-    init(frame: CGRect, paperStyle: PaperStyle) {
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    init(paperStyle: PaperStyle) {
         self.paperStyle = paperStyle
-        super.init(frame: frame)
+        super.init(frame: .zero)
         initView()
         setupConstraints()
     }
@@ -45,7 +49,7 @@ class PaperPresentView: UIView {
 extension PaperPresentView: UIScrollViewDelegate {
 
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
-        return scrollView
+        return stackView
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -61,7 +65,7 @@ extension PaperPresentView: UIScrollViewDelegate {
 extension PaperPresentView {
 
     func addPage(_ pageView: BasePaper) {
-
+        stackView.addArrangedSubview(pageView)
     }
 
     func saveAndExit() {
@@ -77,6 +81,7 @@ extension PaperPresentView {
 private extension PaperPresentView {
 
     func initView() {
+        scrollView.addSubview(stackView)
         scrollView.delegate = self
         scrollView.maximumZoomScale = paperStyle.maximumZoomIn
         addSubview(scrollView)
@@ -84,12 +89,20 @@ private extension PaperPresentView {
 
     func setupConstraints() {
         let frameGuide = scrollView.frameLayoutGuide
+        let contentGuide = scrollView.contentLayoutGuide
 
         NSLayoutConstraint.activate([
             frameGuide.topAnchor.constraint(equalTo: topAnchor),
             frameGuide.leadingAnchor.constraint(equalTo: leadingAnchor),
             frameGuide.trailingAnchor.constraint(equalTo: trailingAnchor),
-            frameGuide.bottomAnchor.constraint(equalTo: bottomAnchor)
+            frameGuide.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            contentGuide.topAnchor.constraint(equalTo: stackView.topAnchor),
+            contentGuide.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            contentGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+            contentGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
+
+            stackView.widthAnchor.constraint(equalToConstant: paperStyle.paperWidth)
         ])
     }
 }

--- a/Dayol-iOS/UI/DiaryPaper/ViewController/DiaryPaperViewController.swift
+++ b/Dayol-iOS/UI/DiaryPaper/ViewController/DiaryPaperViewController.swift
@@ -59,7 +59,7 @@ class DiaryPaperViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         initView()
-        bindInnerModel()
+        bindPaperModel()
         bindEvent()
     }
     
@@ -102,7 +102,7 @@ class DiaryPaperViewController: UIViewController {
         ])
     }
 
-    private func bindInnerModel() {
+    private func bindPaperModel() {
         // TODO: - RxSwift 적용해서 코드 정리
         guard diaryInnerModel.paperList.isEmpty == false else {
             paperPresentView.isHidden = true

--- a/Dayol-iOS/UI/DiaryPaper/ViewController/DiaryPaperViewController.swift
+++ b/Dayol-iOS/UI/DiaryPaper/ViewController/DiaryPaperViewController.swift
@@ -37,12 +37,16 @@ class DiaryPaperViewController: UIViewController {
         
         return view
     }()
+    private let paperPresentView: PaperPresentView
     
     // MARK: - Init
     
     init(diaryCover: DiaryCoverModel, diaryInner: DiaryInnerModel) {
         self.diaryCoverModel = diaryCover
         self.diaryInnerModel = diaryInner
+        // TODO: - 아직 스크롤 뷰 미구현이라 데모 용 첫 번째 속지만 노출
+        self.paperPresentView = PaperPresentView(paperStyle: diaryInner.paperList[0].paperStyle)
+        self.paperPresentView.translatesAutoresizingMaskIntoConstraints = false
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -55,12 +59,15 @@ class DiaryPaperViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         initView()
+        bindInnerModel()
         bindEvent()
     }
     
     private func initView() {
         view.backgroundColor = .white
         view.addSubview(emptyView)
+        // TODO: - 아직 스크롤 뷰 미구현이라 데모 용 첫 번째 속지만 노출
+        view.addSubview(paperPresentView)
 
         setupNavigationBars()
         setConstraint()
@@ -86,8 +93,27 @@ class DiaryPaperViewController: UIViewController {
             emptyView.topAnchor.constraint(equalTo: view.topAnchor),
             emptyView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             emptyView.leftAnchor.constraint(equalTo: view.leftAnchor),
-            emptyView.rightAnchor.constraint(equalTo: view.rightAnchor)
+            emptyView.rightAnchor.constraint(equalTo: view.rightAnchor),
+            // TODO: - 아직 스크롤 뷰 미구현이라 데모 용 첫 번째 속지만 노출
+            paperPresentView.topAnchor.constraint(equalTo: view.topAnchor),
+            paperPresentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            paperPresentView.leftAnchor.constraint(equalTo: view.leftAnchor),
+            paperPresentView.rightAnchor.constraint(equalTo: view.rightAnchor)
         ])
+    }
+
+    private func bindInnerModel() {
+        // TODO: - RxSwift 적용해서 코드 정리
+        guard diaryInnerModel.paperList.isEmpty == false else {
+            paperPresentView.isHidden = true
+            return
+        }
+
+        let paperModel = diaryInnerModel.paperList[0]
+        let paper = PaperProvider.createPaper(paperType: paperModel.paperType,
+                                              paperStyle: paperModel.paperStyle,
+                                              drawModel: paperModel.drawModelList)
+        paperPresentView.addPage(paper)
     }
 
     private func bindEvent() {


### PR DESCRIPTION
## Description  
- 속지 연동이 너무 늦어져서 테스크를 쪼개서 진행하려고 합니다.  
- 속지 한 장에 대한 데이터를 보여주는 작업을 먼저 진행했습니다.  
- inset, zoomScale등은 추후에 상세 구현에서 구현 할 예정입니다.  



## 생각중인 모델 구조  
다이어리 내부에 속지 구조가 생각보다 복잡하여 고민을 많이했는데요..  
우선 아래처럼 테스트 데이터를 구축하여 프로토타입(?) 제작을 진행 할 예정입니다.  

![IMG_8A7DF2650FCC-1](https://user-images.githubusercontent.com/46941349/109666925-00570f00-7bb3-11eb-99f0-dc8d4983174f.jpeg)


## 속지를 보여주는 구조  
BasePaper를 서브클래싱 하는 다양한 속지들을 보여줄 수 있는 
PaperPresentView를 정의하였습니다.

현재는 DiaryPaperViewController에 한 개의 PaperPresentView만 있지만,  
1. 추후에 DiaryPaperViewController에 스크롤 뷰를 정의하고 여러개의 PaperPresentView를 사용하여
여러 종류의 속지들을 포함하게 하거나.  
2. 페이지네이션에 대해 공부를 해서 여러 종류 속지를 (슥슥)넘기는 인터랙션을 구현

할 예정입니다.  

PaperPresentView의 구조는 사진처럼 잡아봤습니다.   
(아마 이전에 어느정도 만들어두어서 git diff에는 잘 안잡힐 것 같아서 사진 올렸습니다.)  

![IMG_CE9861FC3A69-1](https://user-images.githubusercontent.com/46941349/109667579-a0149d00-7bb3-11eb-827e-f5acd37ac3cb.jpeg)
