### PR TITLE
[ADD] 다이어리 순서 변경 후 특정 다이어리에 ContentOffset 조절 기능 구현

### DIFF
--- a/Dayol-iOS/UI/Home/DiaryList/ViewController/DiaryListViewController+CollectionView.swift
+++ b/Dayol-iOS/UI/Home/DiaryList/ViewController/DiaryListViewController+CollectionView.swift
@@ -28,7 +28,7 @@ extension DiaryListViewController: UICollectionViewDelegate {
         var offset = targetContentOffset.pointee
         let idx = round((offset.x + collectionView.contentInset.left) / cellWidthMargin)
 
-        if let indexX = offsetX(index: Int(idx)) {
+        if let indexX = collectionViewOffsetX(index: Int(idx)) {
             offset.x = indexX
             targetContentOffset.pointee = offset
             currentIndex = Int(idx)
@@ -74,7 +74,7 @@ extension DiaryListViewController: UICollectionViewDataSource {
 
 extension DiaryListViewController {
 
-    func offsetX(index: Int) -> CGFloat? {
+    func collectionViewOffsetX(index: Int) -> CGFloat? {
         guard
             let layout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout
         else {
@@ -88,10 +88,16 @@ extension DiaryListViewController {
     }
 
     func moveToIndex(_ index: Int, animated: Bool = true) {
-        guard let offsetX = offsetX(index: index) else { return }
+        guard let offsetX = collectionViewOffsetX(index: index) else { return }
         let offset = CGPoint(x: offsetX, y: 0)
         collectionView.setContentOffset(offset, animated: animated)
         currentIndex = index
+    }
+
+    func moveToCurrentIndexIfNeed() {
+        if let currentEditIndex = currentEditIndex {
+            moveToIndex(currentEditIndex.row)
+        }
     }
 }
 
@@ -134,8 +140,8 @@ extension DiaryListViewController {
                 self.collectionView.endInteractiveMovement()
 
                 // 순서 변경 인터랙션을 수행했지만 결국 순서를 바꾸지 않은 경우
-                if self.hasReorder == false, let currentEditIndex = self.currentEditIndex {
-                    self.moveToIndex(currentEditIndex.row, animated: false)
+                if self.hasReorder == false {
+                    self.moveToCurrentIndexIfNeed()
                 }
             }
         default:
@@ -144,9 +150,7 @@ extension DiaryListViewController {
             collectionView.cancelInteractiveMovement()
             endEditMode()
 
-            if let currentEditIndex = currentEditIndex {
-                moveToIndex(currentEditIndex.row)
-            }
+            moveToCurrentIndexIfNeed()
         }
     }
 

--- a/Dayol-iOS/UI/Home/DiaryList/ViewController/DiaryListViewController+CollectionView.swift
+++ b/Dayol-iOS/UI/Home/DiaryList/ViewController/DiaryListViewController+CollectionView.swift
@@ -65,11 +65,7 @@ extension DiaryListViewController: UICollectionViewDataSource {
         viewModel.moveItem(at: sourceIndexPath.row, to: destinationIndexPath.row)
 
         let idx = destinationIndexPath.row
-
-        if let offsetX = offsetX(index: idx) {
-            let offset = CGPoint(x: offsetX, y: 0)
-            collectionView.setContentOffset(offset, animated: true)
-        }
+        moveToIndex(idx)
     }
 
 }

--- a/Dayol-iOS/UI/Home/DiaryList/ViewController/DiaryListViewController.swift
+++ b/Dayol-iOS/UI/Home/DiaryList/ViewController/DiaryListViewController.swift
@@ -42,7 +42,8 @@ class DiaryListViewController: UIViewController {
     }
     var isEditMode = false
     var canStartInteractiveMovement = false
-    // TODO: - 다이어리 리스트 순서변경 기능 사용 후 해당 인덱스로 스크롤 이동 기능 구현
+    var hasReorder = false
+    var currentIndex = 0
     var currentEditIndex: IndexPath?
 
     // MARK: - UI


### PR DESCRIPTION
- 순서 정렬 이후에 contentOffset이 변경한 대상 다이어리로 이동하도록 수정했습니다.  
- 순서 변경 인터랙션을 진행했지만, 변경이 이뤄지지 않은경우는 해당 다이어리로 다시 초점을 맞춰줬습니다.  

#  

![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/46941349/111636098-80c87180-883b-11eb-9747-2031e9057ae3.gif)
