### PR TITLE
[MOD] 다이어리 생성 화면에서 엔터 키 삭제 및 글자 수 입력 제한되도록 수정

### DIFF
--- a/Dayol-iOS/UI/DiaryEdit/View/DiaryEditViewController.swift
+++ b/Dayol-iOS/UI/DiaryEdit/View/DiaryEditViewController.swift
@@ -147,6 +147,7 @@ class DiaryEditViewController: UIViewController {
         titleView.editButton.rx.tap
             .bind { [weak self] in
                 self?.titleView.isEditting = true
+                self?.titleView.titleTextField.becomeFirstResponder()
             }
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## Description  
- 다이어리 이름 10글자 제한
- 엔터 키 입력 제한(done으로 수정)  
- edit 버튼 탭 시 키보드 올라와서 바로 수정 가능하도록 수정  

## Demo  
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/46941349/111906963-95547600-8a96-11eb-9d9f-653ced8283b2.gif)

