### PR TITLE
다이어리 순서 코어데이터 연동 및 코어데이터 api 수정

### DIFF
--- a/Dayol-iOS.xcodeproj/project.pbxproj
+++ b/Dayol-iOS.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		34AD5A8425C9A87600D9E29C /* PaperListAddCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34AD5A8325C9A87600D9E29C /* PaperListAddCell.swift */; };
 		34ADE2B72663491A00412CAC /* DYFlexibleTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34ADE2B62663491A00412CAC /* DYFlexibleTextField.swift */; };
 		34B6C14125BDB28400C2596F /* DYKeyboardInputAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B6C14025BDB28400C2596F /* DYKeyboardInputAccessoryView.swift */; };
+		34BAEB4F269899E400F9AED7 /* ContentsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BAEB4E269899E400F9AED7 /* ContentsManager.swift */; };
 		34BB085E2612178F0000377E /* EraseSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BB085D2612178F0000377E /* EraseSettingView.swift */; };
 		34BB086226135E030000377E /* EraseOptionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BB086126135E030000377E /* EraseOptionButton.swift */; };
 		34C7B3692619763300BC6A28 /* TextStyleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C7B3682619763300BC6A28 /* TextStyleView.swift */; };
@@ -369,6 +370,7 @@
 		34AD5A8325C9A87600D9E29C /* PaperListAddCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaperListAddCell.swift; sourceTree = "<group>"; };
 		34ADE2B62663491A00412CAC /* DYFlexibleTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DYFlexibleTextField.swift; sourceTree = "<group>"; };
 		34B6C14025BDB28400C2596F /* DYKeyboardInputAccessoryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DYKeyboardInputAccessoryView.swift; sourceTree = "<group>"; };
+		34BAEB4E269899E400F9AED7 /* ContentsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentsManager.swift; sourceTree = "<group>"; };
 		34BB085D2612178F0000377E /* EraseSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EraseSettingView.swift; sourceTree = "<group>"; };
 		34BB086126135E030000377E /* EraseOptionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EraseOptionButton.swift; sourceTree = "<group>"; };
 		34C7B3682619763300BC6A28 /* TextStyleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleView.swift; sourceTree = "<group>"; };
@@ -574,6 +576,7 @@
 				DA5A117C26760F64002C7EA8 /* Paper.swift */,
 				DA5A117F26760F6E002C7EA8 /* PaperScheldule.swift */,
 				34CD663B268A20CC00DECFF7 /* DiaryManager.swift */,
+				34BAEB4E269899E400F9AED7 /* ContentsManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1950,6 +1953,7 @@
 				DAF18E9425B70C26007ACFAC /* Date+Extension.swift in Sources */,
 				3465A643266E547000DF025D /* ColorSettingPaletteViewModel.swift in Sources */,
 				DAEF76BC25F90ED6007CAA93 /* DiaryPaperViewController.swift in Sources */,
+				34BAEB4F269899E400F9AED7 /* ContentsManager.swift in Sources */,
 				0D04C560267F40AC00780EB6 /* MemberShipViewController.swift in Sources */,
 				34BB085E2612178F0000377E /* EraseSettingView.swift in Sources */,
 				3449D2D725AF24DA0050C02A /* AddPaperContentView+UICollectionView.swift in Sources */,

--- a/Dayol-iOS/Data/CoreData/Dayol.xcdatamodeld/DayolModel.xcdatamodel/contents
+++ b/Dayol-iOS/Data/CoreData/Dayol.xcdatamodeld/DayolModel.xcdatamodel/contents
@@ -9,7 +9,6 @@
         <attribute name="width" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="x" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="y" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <relationship name="diary" maxCount="1" deletionRule="No Action" destinationEntity="Diary"/>
         <relationship name="paper" maxCount="1" deletionRule="No Action" destinationEntity="Paper"/>
     </entity>
     <entity name="DecorationStickerItem" representedClassName="DecorationStickerItemMO" parentEntity="DecorationItem" syncable="YES" codeGenerationType="category"/>
@@ -21,6 +20,7 @@
         <attribute name="drawCanvas" attributeType="Binary"/>
         <attribute name="hasLogo" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="id" attributeType="String"/>
+        <attribute name="index" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="isLock" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="thumbnail" attributeType="Binary"/>
         <attribute name="title" attributeType="String"/>
@@ -52,10 +52,10 @@
     </entity>
     <elements>
         <element name="DecorationImageItem" positionX="-315" positionY="-270" width="128" height="29"/>
-        <element name="DecorationItem" positionX="-324" positionY="-270" width="128" height="164"/>
+        <element name="DecorationItem" positionX="-324" positionY="-270" width="128" height="149"/>
         <element name="DecorationStickerItem" positionX="-306" positionY="-261" width="128" height="29"/>
         <element name="DecorationTextFieldItem" positionX="-297" positionY="-252" width="128" height="44"/>
-        <element name="Diary" positionX="-205.9453125" positionY="-438.79296875" width="173.7578125" height="163"/>
+        <element name="Diary" positionX="-205.9453125" positionY="-438.79296875" width="173.7578125" height="164"/>
         <element name="Paper" positionX="-489.12109375" positionY="-332.0703125" width="128" height="209"/>
         <element name="PaperScheduler" positionX="-488.76171875" positionY="-76.8984375" width="128" height="149"/>
     </elements>

--- a/Dayol-iOS/Data/CoreData/Model/DiaryMO+CoreDataClass.swift
+++ b/Dayol-iOS/Data/CoreData/Model/DiaryMO+CoreDataClass.swift
@@ -14,6 +14,7 @@ public class DiaryMO: NSManagedObject {
     func make(diary: Diary) {
         id = diary.id
         isLock = diary.isLock
+        index = diary.index
         title = diary.title
         colorHex = diary.colorHex
         hasLogo = diary.hasLogo
@@ -39,6 +40,7 @@ public class DiaryMO: NSManagedObject {
         return  Diary(
             id: id,
             isLock: isLock,
+            index: index,
             title: title,
             colorHex: colorHex,
             hasLogo: hasLogo,

--- a/Dayol-iOS/Data/CoreData/PersistentManager.swift
+++ b/Dayol-iOS/Data/CoreData/PersistentManager.swift
@@ -59,8 +59,6 @@ class PersistentManager {
     }
 
     func managedObject<T: NSManagedObject>(_ type: EntityType, class: T.Type) -> T? {
-        let context = context
-
         if let entity = entity(.diary) {
             return T(entity: entity, insertInto: context)
         }

--- a/Dayol-iOS/Data/CoreData/PersistentManager.swift
+++ b/Dayol-iOS/Data/CoreData/PersistentManager.swift
@@ -54,19 +54,26 @@ class PersistentManager {
         }
     }
 
-    func entity(_ type: EntityType) -> NSEntityDescription? {
+    private func entity(_ type: EntityType) -> NSEntityDescription? {
         return NSEntityDescription.entity(forEntityName: type.name, in: persistentContainer.viewContext)
+    }
+
+    func managedObject<T: NSManagedObject>(_ type: EntityType, class: T.Type) -> T? {
+        let context = context
+
+        if let entity = entity(.diary) {
+            return T(entity: entity, insertInto: context)
+        }
+        return nil
     }
 
     func insertObject(_ type: EntityType) -> NSManagedObject {
         return NSEntityDescription.insertNewObject(forEntityName: type.name, into: persistentContainer.viewContext)
     }
-}
 
-extension NSManagedObject {
-    static func fetchRequest<T: NSManagedObject>() -> NSFetchRequest<T>? {
-        guard let name = entity().name else { return nil }
-        return NSFetchRequest<T>(entityName: name)
+    func deleteManagedObject(_ object: NSManagedObject) {
+        context.delete(object)
+        saveContext()
     }
 }
 

--- a/Dayol-iOS/Data/Model/ContentsManager.swift
+++ b/Dayol-iOS/Data/Model/ContentsManager.swift
@@ -1,0 +1,32 @@
+//
+//  ContentsManager.swift
+//  Dayol-iOS
+//
+//  Created by 주성민 on 2021/07/09.
+//
+
+import Foundation
+
+class ContentsManager {
+    static let shared = ContentsManager()
+
+    func addContents(to diaryMO: DiaryMO, items: [DecorationItem]) {
+        items.forEach {
+            // TODO: - 상속 구조로 다듬을 수 없는지?
+
+            if let textFieldItem = $0 as? DecorationTextFieldItem {
+                // DecorationTextFieldItem
+                let managedObject = PersistentManager.shared.insertObject(.decorationTextFieldItem)
+
+                guard let textFieldItemMO = managedObject as? DecorationTextFieldItemMO else { return}
+
+                textFieldItemMO.make(item: textFieldItem)
+                diaryMO.addToContents(textFieldItemMO)
+            } else if let imageItem = $0 as? DecorationImageItem {
+                // DecorationImageItem
+            } else if let sticker = $0 as? DecorationStickerItem {
+                // DecorationStickerItem
+            }
+        }
+    }
+}

--- a/Dayol-iOS/Data/Model/Diary.swift
+++ b/Dayol-iOS/Data/Model/Diary.swift
@@ -11,6 +11,7 @@ struct Diary {
     let id: String // D1, D2
     // TODO: - 패스워드 모델 정해진 후 재 구현(isLock)
     var isLock: Bool = false
+    var index: Int32
     let title: String
     let colorHex: String
 

--- a/Dayol-iOS/Data/Model/DiaryManager.swift
+++ b/Dayol-iOS/Data/Model/DiaryManager.swift
@@ -28,7 +28,7 @@ extension DiaryManager {
         }
 
         diaryMO.make(diary: diary)
-        addContents(to: diaryMO, items: diary.contents)
+        ContentsManager.shared.addContents(to: diaryMO, items: diary.contents)
         PersistentManager.shared.saveContext()
         fetchDiaryList()
     }
@@ -69,7 +69,7 @@ extension DiaryManager {
         guard let diaryMO = getDiaryMO(id: diary.id) else { return }
 
         diaryMO.make(diary: diary)
-        addContents(to: diaryMO, items: diary.contents)
+        ContentsManager.shared.addContents(to: diaryMO, items: diary.contents)
         PersistentManager.shared.saveContext()
     }
 
@@ -137,23 +137,4 @@ extension DiaryManager {
         return result.first
     }
 
-    private func addContents(to diaryMO: DiaryMO, items: [DecorationItem]) {
-        items.forEach {
-            // TODO: - 상속 구조로 다듬을 수 없는지?
-
-            if let textFieldItem = $0 as? DecorationTextFieldItem {
-                // DecorationTextFieldItem
-                let managedObject = PersistentManager.shared.insertObject(.decorationTextFieldItem)
-
-                guard let textFieldItemMO = managedObject as? DecorationTextFieldItemMO else { return}
-
-                textFieldItemMO.make(item: textFieldItem)
-                diaryMO.addToContents(textFieldItemMO)
-            } else if let imageItem = $0 as? DecorationImageItem {
-                // DecorationImageItem
-            } else if let sticker = $0 as? DecorationStickerItem {
-                // DecorationStickerItem
-            }
-        }
-    }
 }

--- a/Dayol-iOS/Data/Model/DiaryManager.swift
+++ b/Dayol-iOS/Data/Model/DiaryManager.swift
@@ -12,7 +12,7 @@ import CoreData
 class DiaryManager {
     static let shared = DiaryManager()
     var diaryList: [Diary] = []
-    let needsUpdateDiaryList = ReplaySubject<Void>.createUnbounded()
+    let needsUpdateDiaryList = BehaviorSubject<Void>(value: ())
 
     private init() {
         fetchDiaryList()

--- a/Dayol-iOS/UI/DiaryEdit/View/DiaryEditViewController.swift
+++ b/Dayol-iOS/UI/DiaryEdit/View/DiaryEditViewController.swift
@@ -278,11 +278,10 @@ private extension DiaryEditViewController {
         guard let title = self.titleView.titleLabel.text else { return }
         let diaryView = self.diaryEditCoverView.diaryView
 
-        let diaryID = viewModel.diaryIdToCreate
         let isLock = password != nil
         let drawing = drawingContentView.canvas.drawing
         let hasLogo = diaryView.hasLogo
-        let contents = createContents(diaryID: diaryID)
+        let contents = createContents(diaryID: viewModel.diaryID)
         var drawCanvasData = Data()
 
         let encoder = JSONEncoder()
@@ -290,16 +289,16 @@ private extension DiaryEditViewController {
             drawCanvasData = drawingData
         }
 
-        let diaryModel = Diary(id: diaryID,
-                               isLock: isLock,
-                               title: title,
-                               colorHex: currentCoverColor.hexString,
-                               hasLogo: hasLogo,
-                               thumbnail: diaryEditCoverView.asThumbnail?.pngData() ?? Data(),
-                               drawCanvas: drawCanvasData,
-                               contents: contents)
+        viewModel.createDiaryInfo(
+            isLock: isLock,
+            title: title,
+            colorHex: currentCoverColor.hexString,
+            drawCanvas: drawCanvasData,
+            hasLogo: hasLogo,
+            thumbnail: diaryEditCoverView.asThumbnail?.pngData() ?? Data(),
+            contents: contents
+        )
 
-        self.viewModel.createDiaryInfo(model: diaryModel)
         self.dismiss(animated: true, completion: nil)
     }
 

--- a/Dayol-iOS/UI/DiaryEdit/ViewModel/DiaryEditViewModel.swift
+++ b/Dayol-iOS/UI/DiaryEdit/ViewModel/DiaryEditViewModel.swift
@@ -15,17 +15,52 @@ class DiaryEditViewModel {
     var diarySubject = ReplaySubject<Diary>.createUnbounded()
     var currentDiaryId: String?
 
-    var diaryIdToCreate: String {
+    var diaryID: String {
+        let diaryPrefix = "D"
         if let diaryId = currentDiaryId {
             return diaryId
         }
+        return diaryPrefix + String(Date().timeIntervalSince1970)
+    }
 
-        if let diaryList = try? DiaryManager.shared.diaryListSubject.value() {
-            let count = diaryList.count
-            return "D\(count)"
+    var diaryIndex: Int32 {
+        let diaryList = DiaryManager.shared.diaryList
+
+        if let index = diaryList.firstIndex(where: { $0.id == diaryID }) {
+            return Int32(index)
         }
 
-        return "D0"
+        return Int32(diaryList.count)
+    }
+
+    func createDiaryInfo(
+        isLock: Bool,
+        title: String,
+        colorHex: String,
+        drawCanvas: Data,
+        hasLogo: Bool,
+        thumbnail: Data,
+        contents: [DecorationItem]
+    ) {
+        let diaryModel = Diary(
+            id: diaryID,
+            isLock: isLock,
+            index: diaryIndex,
+            title: title,
+            colorHex: colorHex,
+            hasLogo: hasLogo,
+            thumbnail: thumbnail,
+            drawCanvas: drawCanvas,
+            contents: contents
+        )
+
+        if currentDiaryId == nil {
+            DiaryManager.shared.createDiary(diaryModel)
+        } else {
+            DiaryManager.shared.updateDiary(diaryModel)
+            DiaryManager.shared.fetchDiaryList()
+        }
+
     }
 
     func createDiaryInfo(model: Diary) {

--- a/Dayol-iOS/UI/Home/DiaryList/ViewModel/DiaryListViewModel.swift
+++ b/Dayol-iOS/UI/Home/DiaryList/ViewModel/DiaryListViewModel.swift
@@ -13,7 +13,9 @@ class DiaryListViewModel {
         case fetch(isEmpty: Bool)
     }
 
-    private(set) var diaryList: [Diary] = []
+    var diaryList: [Diary] {
+        return DiaryManager.shared.diaryList
+    }
     var diaryFetchEvent = ReplaySubject<Void>.createUnbounded()
 
     init() {
@@ -21,10 +23,9 @@ class DiaryListViewModel {
     }
     
     private func bind() {
-        DiaryManager.shared.diaryListSubject
-            .subscribe(onNext: { [weak self] model in
+        DiaryManager.shared.needsUpdateDiaryList
+            .subscribe(onNext: { [weak self] in
                 guard let self = self else { return }
-                self.diaryList = model
                 self.diaryFetchEvent.onNext(())
             })
             .disposed(by: disposeBag)
@@ -45,19 +46,7 @@ extension DiaryListViewModel {
 extension DiaryListViewModel {
 
     func moveItem(at sourceIndex: Int, to destinationIndex: Int) {
-        guard let sourceModel = diaryList[safe: sourceIndex] else {
-            // 로거 추가 필요
-            debugPrint("[DiaryList] wrong move index")
-            return
-        }
-
-        if sourceIndex > destinationIndex {
-            diaryList.remove(at: sourceIndex)
-            diaryList.insert(sourceModel, at: destinationIndex)
-        } else {
-            diaryList.insert(sourceModel, at: destinationIndex + 1)
-            diaryList.remove(at: sourceIndex)
-        }
+        DiaryManager.shared.updateDiaryOrder(at: sourceIndex, to: destinationIndex)
     }
 
 }


### PR DESCRIPTION
- 다이어리 리스트 순서 코어데이터 연동
  -> 다이어리 아이디를 D + 현재 타임스탬프 값을 사용하도록 수정 
- PersistantManager의 context에 접근하지 않도록 제네릭 함수 구현